### PR TITLE
use dependency from package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var phantomJSExePath = function () {
   // Using the cmd as the process to execute causes problems cleaning up the processes
   // so we walk from the cmd to the phantomjs.exe and use that instead.
 
-  var phantomSource = require('phantomjs2').path;
+  var phantomSource = require('phantomjs2-ext').path;
 
   if (path.extname(phantomSource).toLowerCase() === '.cmd') {
     return path.join(path.dirname( phantomSource ), '//node_modules//phantomjs2//lib//phantom//phantomjs.exe');
@@ -58,8 +58,8 @@ PhantomJSBrowser.prototype = {
   name: 'PhantomJS2',
 
   DEFAULT_CMD: {
-    linux: require('phantomjs2').path,
-    darwin: require('phantomjs2').path,
+    linux: require('phantomjs2-ext').path,
+    darwin: require('phantomjs2-ext').path,
     win32: phantomJSExePath()
   },
   ENV_CMD: 'PHANTOMJS_BIN'


### PR DESCRIPTION
I noticed that there is `phantomjs2-ext` in `package.json`, but in the code `phantomjs2` is actually used. Due to this fact one has to install `phantomjs2` alongside this module to get it to work. However `phantomjs2` is missing the patch containing the `PHANTOMJS2_DOWNLOAD_URL` from `phantomjs2-ext`.

Hopefully things get easier now that there's a stable version of PhantomJS 2. This is just a quick fix.
