### PR TITLE
Bump dependencies to support iojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
   ],
   "author": "Alexandr Skackhov <gskachkov@gmail.com>",
   "dependencies": {
-    "phantomjs2-ext": "^0.0.4"
+    "phantomjs2-ext": "^0.0.6"
   },
   "peerDependencies": {
     "karma": ">=0.9"
   },
   "license": "MIT",
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-auto-release": "~0.0.2",
-    "grunt-bump": "~0.0.7",
+    "grunt": "~0.4.5",
+    "grunt-auto-release": "~0.0.6",
+    "grunt-bump": "~0.3.1",
     "grunt-npm": "~0.0.2"
   },
   "contributors": [


### PR DESCRIPTION
Since phantomjs-ext v0.0.6 adds support to iojs, this package should upgrade too
